### PR TITLE
Fix: Import QTcpSocket from PySide6.QtNetwork

### DIFF
--- a/debug_manager.py
+++ b/debug_manager.py
@@ -2,7 +2,8 @@ import json
 import socket # For finding an open port
 from contextlib import closing
 import sys # For sys.executable
-from PySide6.QtCore import QObject, Signal, QProcess, QTcpSocket, QThread, QTimer
+from PySide6.QtCore import QObject, Signal, QProcess, QThread, QTimer
+from PySide6.QtNetwork import QTcpSocket
 from PySide6.QtNetwork import QAbstractSocket # For error types if needed
 
 class DebugManager(QObject):


### PR DESCRIPTION
The QTcpSocket class was incorrectly imported from PySide6.QtCore. This commit changes the import statement to use PySide6.QtNetwork, which is the correct module for QTcpSocket.

This resolves the ImportError that occurred when trying to import QTcpSocket from PySide6.QtCore.